### PR TITLE
fix: setAudioSettings were used instead of setVideoSettings

### DIFF
--- a/lib/rtmp_stream.dart
+++ b/lib/rtmp_stream.dart
@@ -40,7 +40,7 @@ class RtmpStream extends NetStream {
   set videoSettings(VideoSettings videoSettings) {
     assert(_memory != null);
     _videoSettings = videoSettings;
-    RtmpStreamPlatform.instance.setAudioSettings(
+    RtmpStreamPlatform.instance.setVideoSettings(
         {"memory": _memory, "settings": videoSettings.toMap()});
   }
 
@@ -60,7 +60,7 @@ class RtmpStream extends NetStream {
   set captureSettings(CaptureSettings captureSettings) {
     assert(_memory != null);
     _captureSettings = captureSettings;
-    RtmpStreamPlatform.instance.setAudioSettings(
+    RtmpStreamPlatform.instance.setCaptureSettings(
         {"memory": _memory, "settings": captureSettings.toMap()});
   }
 


### PR DESCRIPTION
## Description & motivation
setAudioSettings were used in set videoSettings and set captureSettings, so all videoSettings changes were ignored.
```  @override
  set videoSettings(VideoSettings videoSettings) {
    assert(_memory != null);
    _videoSettings = videoSettings;
    RtmpStreamPlatform.instance.setAudioSettings( // <- this should to be RtmpStreamPlatform.instance.setVideoSettings(
        {"memory": _memory, "settings": videoSettings.toMap()});
  }
```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


