### PR TITLE
Fix: Android - Pass audioSettings.muted to RtmpStream

### DIFF
--- a/android/src/main/kotlin/com/haishinkit/haishin_kit/RtmpStreamHandler.kt
+++ b/android/src/main/kotlin/com/haishinkit/haishin_kit/RtmpStreamHandler.kt
@@ -53,6 +53,9 @@ class RtmpStreamHandler(
                 (source["bitrate"] as? Int)?.let {
                     instance?.audioSetting?.bitRate = it
                 }
+                (source["muted"] as? Boolean)?.let {
+                    instance?.audioSetting?.muted = it
+                }
                 result.success(null)
             }
             "$TAG#setVideoSettings" -> {


### PR DESCRIPTION
## Description & motivation

Allows muting a stream on Android by calling: `stream.audioSettings = AudioSettings(muted: true)`

Related discussion: https://github.com/shogo4405/HaishinKit.dart/discussions/20

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
