### PR TITLE
addEventListener for RtmpStream on Android

### DIFF
--- a/android/src/main/kotlin/com/haishinkit/haishin_kit/RtmpStreamHandler.kt
+++ b/android/src/main/kotlin/com/haishinkit/haishin_kit/RtmpStreamHandler.kt
@@ -42,6 +42,7 @@ class RtmpStreamHandler(
     init {
         handler?.instance?.let {
             instance = RtmpStream(it)
+            instance?.addEventListener(Event.RTMP_STATUS, this)
         }
         channel = EventChannel(
             plugin.flutterPluginBinding.binaryMessenger, "com.haishinkit.eventchannel/${hashCode()}"


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
-->

Fix: https://github.com/shogo4405/HaishinKit.dart/issues/42

## Description & motivation

For the iOS side, we could receive the `Event.RTMP_STATUS` via `RtmpConnection.eventChannel` and `RtmpStream.eventChannel`, while we can only receive the `RtmpConnection`'s `Event.RTMP_STATUS` for the Android side.

<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

## Type of change
I believe it is caused by missing `addEventListener` for `RtmpStreamHanlder`, so I added an event listener in `RtmpStreamHandler.init`.
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots:
Before adding this event listener, I can only receive the `RtmpConnectionEvent`:
<img width="969" alt="image" src="https://github.com/shogo4405/HaishinKit.dart/assets/55259373/39cb1bc8-4cef-4629-b96e-3685a5564b9a">

After adding this event listener, I will also receive the `RtmpStreamEvent.publishStart`:
<img width="857" alt="image" src="https://github.com/shogo4405/HaishinKit.dart/assets/55259373/742ae307-ea16-487a-b100-54855d1acc23">

Note: both `RtmpConnectionEvent` and `RtmpStremEvent` are mapped from the data of dart `EventChannel`
